### PR TITLE
Remove PHP 7.4 from `allow_failures` matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
 
 jobs:
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
 
   include:


### PR DESCRIPTION
In order to ensure that this project is forward compatible with `PHP 7.4`, let's allow the jobs to fail.