### PR TITLE
Parametrise id injection property

### DIFF
--- a/src/InputDataInjector.php
+++ b/src/InputDataInjector.php
@@ -9,7 +9,12 @@ use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
 
 final class InputDataInjector
 {
-    public const GENERATED_ID = '_input.id';
+    private $generatedProperty = '_input.id';
+
+    public function __construct(string $generatedProperty = '_input.id')
+    {
+        $this->generatedProperty = $generatedProperty;
+    }
 
     public function injectData(PreDeserializeEvent $event): void
     {
@@ -34,7 +39,7 @@ final class InputDataInjector
         $generatedId = $input->getAttribute(IdentifierGenerator::class);
 
         if ($generatedId !== null) {
-            $data[self::GENERATED_ID] = $generatedId;
+            $data[$this->generatedProperty] = $generatedId;
         }
 
         return $data;

--- a/src/InputDataInjector.php
+++ b/src/InputDataInjector.php
@@ -38,7 +38,7 @@ final class InputDataInjector
     {
         $generatedId = $input->getAttribute(IdentifierGenerator::class);
 
-        if ($generatedId !== null) {
+        if ($generatedId !== null && isset($data[$this->generatedProperty]) === false) {
             $data[$this->generatedProperty] = $generatedId;
         }
 

--- a/tests/Functional/DoSomething.php
+++ b/tests/Functional/DoSomething.php
@@ -3,14 +3,12 @@ declare(strict_types=1);
 
 namespace Chimera\MessageCreator\JmsSerializer\Tests\Functional;
 
-use Chimera\MessageCreator\JmsSerializer\InputDataInjector;
 use JMS\Serializer\Annotation as Serializer;
 
 final class DoSomething
 {
     /**
      * @Serializer\Type("string")
-     * @Serializer\SerializedName(InputDataInjector::GENERATED_ID)
      * @var string|null
      */
     public $id;

--- a/tests/Functional/MessageDeserializationTest.php
+++ b/tests/Functional/MessageDeserializationTest.php
@@ -34,7 +34,7 @@ final class MessageDeserializationTest extends TestCase
      */
     public function createSerializer(): void
     {
-        $injector = new InputDataInjector();
+        $injector = new InputDataInjector('id');
 
         $addListeners = static function (EventDispatcher $dispatcher) use ($injector): void {
             $dispatcher->addListener(Events::PRE_DESERIALIZE, [$injector, 'injectData']);

--- a/tests/Unit/InputDataInjectorTest.php
+++ b/tests/Unit/InputDataInjectorTest.php
@@ -139,4 +139,20 @@ final class InputDataInjectorTest extends TestCase
 
         self::assertSame(['test' => 1, '_input.id' => 'abc123'], $this->event->getData());
     }
+
+    /**
+     * @test
+     */
+    public function injectDataShouldNotInjectAnythingIfThePropertyIsAlreadySet(): void
+    {
+        $this->input->expects(self::once())
+                    ->method('getAttribute')
+                    ->with(IdentifierGenerator::class)
+                    ->willReturn(4);
+
+        $listener = new InputDataInjector('test');
+        $listener->injectData($this->event);
+
+        self::assertSame(['test' => 1], $this->event->getData());
+    }
 }

--- a/tests/Unit/InputDataInjectorTest.php
+++ b/tests/Unit/InputDataInjectorTest.php
@@ -19,7 +19,8 @@ use function assert;
  */
 final class InputDataInjectorTest extends TestCase
 {
-    private const DATA = ['test' => 1];
+    private const DATA     = ['test' => 1];
+    private const PROPERTY = 'id';
 
     /**
      * @var Input|MockObject
@@ -75,7 +76,7 @@ final class InputDataInjectorTest extends TestCase
 
         $context->increaseDepth();
 
-        $listener = new InputDataInjector();
+        $listener = new InputDataInjector(self::PROPERTY);
         $listener->injectData($this->event);
 
         self::assertSame(self::DATA, $this->event->getData());
@@ -117,9 +118,25 @@ final class InputDataInjectorTest extends TestCase
                     ->with(IdentifierGenerator::class)
                     ->willReturn('abc123');
 
+        $listener = new InputDataInjector(self::PROPERTY);
+        $listener->injectData($this->event);
+
+        self::assertSame(['test' => 1, self::PROPERTY => 'abc123'], $this->event->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function injectDataShouldUseTheCorrectDefaultValueWhenAddingGeneratedIdToData(): void
+    {
+        $this->input->expects(self::once())
+                    ->method('getAttribute')
+                    ->with(IdentifierGenerator::class)
+                    ->willReturn('abc123');
+
         $listener = new InputDataInjector();
         $listener->injectData($this->event);
 
-        self::assertSame(['test' => 1, InputDataInjector::GENERATED_ID => 'abc123'], $this->event->getData());
+        self::assertSame(['test' => 1, '_input.id' => 'abc123'], $this->event->getData());
     }
 }


### PR DESCRIPTION
This PR makes two changes to this package, solving the issue raised in #15 .

The first change is making `InputDataInjector` parametrisable, meaning that it is now possible to specify under which property should the generated id be saved.
This has been defaulted to the previous value, `_input.id`, in order to remain backwards compatible.

The second change is to not override the property in case it is already present, in order not to tamper with information coming from clients.
This second change would allow Chimera to support both id generation on BE and FE sides.